### PR TITLE
Be/editorservice

### DIFF
--- a/database_query.sql
+++ b/database_query.sql
@@ -93,6 +93,8 @@ CREATE TABLE ArticleTags (
     FOREIGN KEY (tag_id) REFERENCES Tags(tag_id)
 );
 
+ALTER TABLE Users ADD managed_category_id INT;
+ALTER TABLE Users ADD FOREIGN KEY (managed_category_id) REFERENCES Categories(category_id);
 
 -- Phake data
 USE OnlineNewspaper;

--- a/src/services/article.service.js
+++ b/src/services/article.service.js
@@ -121,6 +121,36 @@ export default {
               'users.full_name as commenter_name'
           )
           .orderBy('comments.created_at', 'asc');
-  }
+  },
+
+  getPendingArticles(editorId) {
+    return db('articles')
+      .leftJoin('categories', 'articles.category_id', 'categories.category_id')
+      .leftJoin('users', 'articles.editor_id', 'users.user_id')
+      .where('articles.status', 'waiting')
+      .andWhere('users.user_id', editorId)
+      .andWhere(function () {
+        this.where('articles.category_id', function () {
+          this.select('managed_category_id')
+            .from('users')
+            .where('user_id', editorId);
+        }).orWhere('categories.belong_to', function () {
+          this.select('managed_category_id')
+            .from('users')
+            .where('user_id', editorId);
+        });
+      })
+      .select(
+        'articles.article_id',
+        'articles.title',
+        'articles.abstract',
+        'articles.thumbnail',
+        'articles.views',
+        'articles.status',
+        'articles.published_date',
+        'articles.is_premium'
+      )
+      .orderBy('articles.published_date', 'desc');
+  },
 
 };


### PR DESCRIPTION
added two methods for editors in article.service.js:
- updateArticleStatus
- getPendingArticles
add a column in the Users table to save the main category that each editor manages.
