### PR TITLE
List of articles by tags

### DIFF
--- a/src/controllers/tag.controller.js
+++ b/src/controllers/tag.controller.js
@@ -1,0 +1,36 @@
+import TagService from "../services/tag.service.js";
+
+const ITEMS_PER_PAGE = 10; // Số bài viết trên mỗi trang
+
+export default {
+	// Hiển thị danh sách bài viết theo tag
+	async getArticlesByTag(req, res) {
+		try {
+			const tagId = req.query.id;
+			const page = parseInt(req.query.page) || 1;
+
+			// Kiểm tra tag có tồn tại không
+			const tag = await TagService.findTagById(tagId);
+			if (!tag) {
+				return res.status(404).render("vwError/404", { message: "Tag not found" });
+			}
+
+			// Lấy danh sách bài viết theo tag
+			const result = await TagService.findArticlesByTag(tagId, page, ITEMS_PER_PAGE);
+
+			const { articles, totalPages } = result;
+
+			// Truyền tag và bài viết vào view
+			res.render("../views/vwHomepage/List_byTag.ejs", {
+				tag,
+				articles,
+				currentPage: page,
+				totalPages,
+				tagId,
+			});
+		} catch (error) {
+			console.error("Error in getArticlesByTag:", error);
+			res.status(500).render("vwError/500", { message: "Internal Server Error" });
+		}
+	},
+};

--- a/src/routes/api.routes.js
+++ b/src/routes/api.routes.js
@@ -1,6 +1,7 @@
 // API routes here
 import { Router } from "express";
 import apiController from "../controllers/api.controller.js";
+import tagController from "../controllers/tag.controller.js";
 import upload from "../config/upload.js";
 
 const router = Router();
@@ -10,5 +11,7 @@ router.post("/images/upload", upload.single("image"), apiController.imgUpload);
 
 // API to get category list
 router.get("/categories", apiController.getCategories);
+
+router.get("/homepage/tag", tagController.getArticlesByTag);
 
 export default router;

--- a/src/routes/api.routes.js
+++ b/src/routes/api.routes.js
@@ -1,7 +1,6 @@
 // API routes here
 import { Router } from "express";
 import apiController from "../controllers/api.controller.js";
-import tagController from "../controllers/tag.controller.js";
 import upload from "../config/upload.js";
 
 const router = Router();
@@ -11,7 +10,5 @@ router.post("/images/upload", upload.single("image"), apiController.imgUpload);
 
 // API to get category list
 router.get("/categories", apiController.getCategories);
-
-router.get("/homepage/tag", tagController.getArticlesByTag);
 
 export default router;

--- a/src/routes/homepage.routes.js
+++ b/src/routes/homepage.routes.js
@@ -1,6 +1,7 @@
 import express from "express";
 import homeController from "../controllers/homepage.controller.js";
 import articleService from "../services/article.service.js";
+import tagController from "../controllers/tag.controller.js";
 const router = express.Router();
 
 router.get("/", homeController.GetHomepage);
@@ -24,4 +25,7 @@ router.get("/art-card", async (req, res) => {
 router.get("/list", function (req, res) {
 	res.render("vwHomepage/List");
 });
+
+router.get("/tag", tagController.getArticlesByTag);
+
 export default router;

--- a/src/services/tag.service.js
+++ b/src/services/tag.service.js
@@ -1,45 +1,75 @@
-import db from '../config/db.js';
+import db from "../config/db.js";
 
 export default {
-  // Lấy tất cả các tags
-  findAllTags() {
-    return db('tags').select('tag_id', 'tag_name');
-  },
+	// Lấy tất cả các tags
+	findAllTags() {
+		return db("tags").select("tag_id", "tag_name");
+	},
 
-  // Thêm một tag mới
-  addTag(tagName) {
-    return db('tags').insert({ tag_name: tagName });
-  },
+	// Tìm tag theo ID
+	findTagById(tagId) {
+		return db("tags").where("tag_id", tagId).first();
+	},
 
-  // Lấy tất cả các tags của một bài viết cụ thể
-  findTagsByArticleId(articleId) {
-    return db('tags')
-      .join('articletags', 'tags.tag_id', 'articletags.tag_id')
-      .where('articletags.article_id', articleId)
-      .select('tags.tag_id', 'tags.tag_name');
-  },
+	// Lấy danh sách bài viết theo tag ID + Phân trang
+	findArticlesByTag(tagId, page, itemsPerPage) {
+		const offset = (page - 1) * itemsPerPage;
 
-  // Thêm các tags cho một bài viết cụ thể
-  addTagsToArticle(articleId, tagIds) {
-    const articleTags = tagIds.map(tagId => ({
-      article_id: articleId,
-      tag_id: tagId
-    }));
-    return db('articletags').insert(articleTags);
-  },
+		const articlesQuery = db("articles")
+			.join("articletags", "articles.article_id", "articletags.article_id")
+			.join("categories", "articles.category_id", "categories.category_id")
+			.where("articletags.tag_id", tagId)
+			.andWhere("articles.status", "published") // Chỉ lấy bài viết đã xuất bản
+			.select("articles.article_id", "articles.title", "articles.abstract", "articles.thumbnail", "articles.published_date", "categories.category_name")
+			.orderBy("articles.published_date", "desc")
+			.limit(itemsPerPage)
+			.offset(offset);
 
-  // Xóa tất cả các tags của một bài viết cụ thể
-  removeTagsFromArticle(articleId) {
-    return db('articletags').where('article_id', articleId).del();
-  },
+		const countQuery = db("articles")
+			.join("articletags", "articles.article_id", "articletags.article_id")
+			.where("articletags.tag_id", tagId)
+			.andWhere("articles.status", "published")
+			.count("articles.article_id as count");
 
-  // Xóa một tag cụ thể
-  deleteTag(tagId) {
-    return db('tags').where('tag_id', tagId).del();
-  },
+		return Promise.all([articlesQuery, countQuery]).then(([articles, countResult]) => {
+			const totalItems = countResult[0].count;
+			const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  // Cập nhật tên của một tag cụ thể
-  updateTag(tagId, tagName) {
-    return db('tags').where('tag_id', tagId).update({ tag_name: tagName });
-  }
+			return { articles, totalPages };
+		});
+	},
+
+	// Thêm một tag mới
+	addTag(tagName) {
+		return db("tags").insert({ tag_name: tagName });
+	},
+
+	// Lấy tất cả các tags của một bài viết cụ thể
+	findTagsByArticleId(articleId) {
+		return db("tags").join("articletags", "tags.tag_id", "articletags.tag_id").where("articletags.article_id", articleId).select("tags.tag_id", "tags.tag_name");
+	},
+
+	// Thêm các tags cho một bài viết cụ thể
+	addTagsToArticle(articleId, tagIds) {
+		const articleTags = tagIds.map((tagId) => ({
+			article_id: articleId,
+			tag_id: tagId,
+		}));
+		return db("articletags").insert(articleTags);
+	},
+
+	// Xóa tất cả các tags của một bài viết cụ thể
+	removeTagsFromArticle(articleId) {
+		return db("articletags").where("article_id", articleId).del();
+	},
+
+	// Xóa một tag cụ thể
+	deleteTag(tagId) {
+		return db("tags").where("tag_id", tagId).del();
+	},
+
+	// Cập nhật tên của một tag cụ thể
+	updateTag(tagId, tagName) {
+		return db("tags").where("tag_id", tagId).update({ tag_name: tagName });
+	},
 };

--- a/src/views/layouts/reader.main.ejs
+++ b/src/views/layouts/reader.main.ejs
@@ -11,7 +11,7 @@
 			crossorigin="anonymous"
 		/>
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
-		<link rel="stylesheet" href="css/layouts/reader.main.css" />
+		<link rel="stylesheet" href="/css/layouts/reader.main.css" />
 		<link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 	</head>

--- a/src/views/partials/article_sr.ejs
+++ b/src/views/partials/article_sr.ejs
@@ -3,7 +3,7 @@
 <style>
 	.card-s {
 		width: <%= width %>;
-		max-width: 500px;
+		max-width: none;
 		margin: 0 auto;
 	}
 	.card-s .category-text {
@@ -26,8 +26,8 @@
 	}
 </style>
 
-<div class="card-wrapper card-s d-flex align-items-center justify-content-between">
-	<div class="card-content w-50">
+<div class="card-wrapper card-s d-flex align-items-center justify-content-between border-bottom">
+	<div class="card-content w-70">
 		<% if (typeof show_cat !== 'undefined' && show_cat) { %>
 		<div class="category-text">
 			<a href="/category/<%= article.category_id %>" class="text-decoration-none text-reset"> <%= article.category_name %> </a>
@@ -41,5 +41,5 @@
 			<p class="mb-1"><%= new Date(article.published_date).toLocaleDateString('vi-VN') %></p>
 		</div>
 	</div>
-	<img src="/img/<%= article.thumbnail %>" alt="<%= article.title %>" class="img-fluid w-50 pl-3" style="height: 150px; object-fit: cover" />
+	<img src="/img/<%= article.thumbnail %>" alt="<%= article.title %>" class="img-fluid w-30 pl-3" style="height: 150px; object-fit: cover" />
 </div>

--- a/src/views/partials/article_sr.ejs
+++ b/src/views/partials/article_sr.ejs
@@ -40,6 +40,11 @@
 			<p class="abstract-text"><%= article.abstract %></p>
 			<p class="mb-1"><%= new Date(article.published_date).toLocaleDateString('vi-VN') %></p>
 		</div>
+		<% article.tags.forEach(tag => { %>
+		<div class="mt-3">
+			<span class="badge badge-primary">tag.tag_name</span>
+		</div>
+		<% }) %>
 	</div>
 	<img src="/img/<%= article.thumbnail %>" alt="<%= article.title %>" class="img-fluid w-50 pl-3" style="height: 150px; object-fit: cover" />
 </div>

--- a/src/views/partials/article_sr.ejs
+++ b/src/views/partials/article_sr.ejs
@@ -40,11 +40,6 @@
 			<p class="abstract-text"><%= article.abstract %></p>
 			<p class="mb-1"><%= new Date(article.published_date).toLocaleDateString('vi-VN') %></p>
 		</div>
-		<% article.tags.forEach(tag => { %>
-		<div class="mt-3">
-			<span class="badge badge-primary">tag.tag_name</span>
-		</div>
-		<% }) %>
 	</div>
 	<img src="/img/<%= article.thumbnail %>" alt="<%= article.title %>" class="img-fluid w-50 pl-3" style="height: 150px; object-fit: cover" />
 </div>

--- a/src/views/vwHomepage/List_byTag.ejs
+++ b/src/views/vwHomepage/List_byTag.ejs
@@ -1,32 +1,27 @@
-<div class="container">
-	<h1>Bài viết với nhãn: <%= tag.tag_name %></h1>
-	<div class="row">
-		<% if (articles.length > 0) { %> <% articles.forEach(article => { %>
-		<div class="col-md-4">
-			<div class="card">
-				<img src="<%= article.thumbnail %>" class="card-img-top" alt="<%= article.title %>" />
-				<div class="card-body">
-					<h5 class="card-title"><%= article.title %></h5>
-					<p class="card-text"><%= article.abstract %></p>
-					<p class="card-text"><small class="text-muted">Ngày đăng: <%= article.published_date %></small></p>
-					<p class="card-text"><strong>Chuyên mục:</strong> <%= article.category_name %></p>
-					<a href="/articles/<%= article.article_id %>" class="btn btn-primary">Đọc thêm</a>
-				</div>
-			</div>
-		</div>
-		<% }); %> <% } else { %>
-		<p>Không có bài viết nào cho nhãn này.</p>
-		<% } %>
+<div class="container-fluid px-5">
+	<div class="border-bottom my-5">
+		<h1><%= tag.tag_name %></h1>
 	</div>
+	<% if (articles.length > 0) { %> <% articles.forEach(article => { %> <%- include('../partials/article_sr.ejs', { article: article, show_cat: true, width: '100%'}) %> <% }); %> <% } else { %>
+	<p>Không có bài viết nào cho nhãn này.</p>
+	<% } %>
 
-	<!-- Phân trang -->
-	<nav aria-label="Page navigation">
-		<ul class="pagination">
-			<% for (let i = 1; i <= totalPages; i++) { %>
-			<li class="page-item <%= i === currentPage ? 'active' : '' %>">
-				<a class="page-link" href="?id=<%= tagId %>&page=<%= i %>"><%= i %></a>
-			</li>
-			<% } %>
-		</ul>
-	</nav>
+	<!-- Pagination -->
+	<ul class="pagination justify-content-center my-3">
+		<li class="page-item <%= currentPage == 1 ? 'disabled' : '' %>">
+			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage-1 %>">Previous</a>
+		</li>
+		<% for (let i = 1; i <= totalPages; i++) { %> <% if (i === currentPage) { %>
+		<li class="page-item active">
+			<a class="page-link" href="#"><%= i %></a>
+		</li>
+		<% } else { %>
+		<li class="page-item">
+			<a class="page-link" href="?id=<%= tagId %>&page=<%= i %>"><%= i %></a>
+		</li>
+		<% }} %>
+		<li class="page-item <%= currentPage == totalPages ? 'disabled' : '' %>">
+			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage+1 %>">Next</a>
+		</li>
+	</ul>
 </div>

--- a/src/views/vwHomepage/List_byTag.ejs
+++ b/src/views/vwHomepage/List_byTag.ejs
@@ -1,0 +1,32 @@
+<div class="container">
+	<h1>Bài viết với nhãn: <%= tag.tag_name %></h1>
+	<div class="row">
+		<% if (articles.length > 0) { %> <% articles.forEach(article => { %>
+		<div class="col-md-4">
+			<div class="card">
+				<img src="<%= article.thumbnail %>" class="card-img-top" alt="<%= article.title %>" />
+				<div class="card-body">
+					<h5 class="card-title"><%= article.title %></h5>
+					<p class="card-text"><%= article.abstract %></p>
+					<p class="card-text"><small class="text-muted">Ngày đăng: <%= article.published_date %></small></p>
+					<p class="card-text"><strong>Chuyên mục:</strong> <%= article.category_name %></p>
+					<a href="/articles/<%= article.article_id %>" class="btn btn-primary">Đọc thêm</a>
+				</div>
+			</div>
+		</div>
+		<% }); %> <% } else { %>
+		<p>Không có bài viết nào cho nhãn này.</p>
+		<% } %>
+	</div>
+
+	<!-- Phân trang -->
+	<nav aria-label="Page navigation">
+		<ul class="pagination">
+			<% for (let i = 1; i <= totalPages; i++) { %>
+			<li class="page-item <%= i === currentPage ? 'active' : '' %>">
+				<a class="page-link" href="?id=<%= tagId %>&page=<%= i %>"><%= i %></a>
+			</li>
+			<% } %>
+		</ul>
+	</nav>
+</div>

--- a/src/views/vwHomepage/List_byTag.ejs
+++ b/src/views/vwHomepage/List_byTag.ejs
@@ -1,4 +1,4 @@
-<div class="container-fluid px-5">
+<div class="container-fluid">
 	<div class="border-bottom my-5">
 		<h1><%= tag.tag_name %></h1>
 	</div>
@@ -9,7 +9,7 @@
 	<!-- Pagination -->
 	<ul class="pagination justify-content-center my-3">
 		<li class="page-item <%= currentPage == 1 ? 'disabled' : '' %>">
-			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage-1 %>">Previous</a>
+			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage-1 %>"><i class="bi bi-caret-left"></i></i></a>
 		</li>
 		<% for (let i = 1; i <= totalPages; i++) { %> <% if (i === currentPage) { %>
 		<li class="page-item active">
@@ -21,7 +21,7 @@
 		</li>
 		<% }} %>
 		<li class="page-item <%= currentPage == totalPages ? 'disabled' : '' %>">
-			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage+1 %>">Next</a>
+			<a class="page-link" href="/homepage/cate?id=<%= tagId %>&page=<%= currentPage+1 %>"><i class="bi bi-caret-right"></i></a>
 		</li>
 	</ul>
 </div>


### PR DESCRIPTION
I am completing the task of building a page to view a list of posts by tags.

**Specifically:**
- Add the router for this page inside the `routes/homepage.routes.js` file.
- Create a new controller file `tag.controller.js` to control the display of the article list and pagination.
- Add 2 services in tag.service.js:
  + `findTagById(tagId)`: to find tag by id.
  + `findArticlesByTag(tagId, page, itemsPerPage)`: To get list of articles by tag ID + pagination.
- Create a new view `vwHomepage/List_byTag.ejs` to display (in here call partial `article_sr`).
- Change the width and add border-bottom of the partial `article.sr` to accommodate full screen list display.
- Fix the path to `custom css` in reader layout.