### PR TITLE
fix: add missing semicolon and improve catch-all route handling

### DIFF
--- a/src/routes/default.routes.js
+++ b/src/routes/default.routes.js
@@ -4,7 +4,7 @@ import { registerValidation } from "../validators/register.validator.js";
 const router = express.Router();
 
 router.get("/", function (req, res) {
-	res.redirect("/homepage")
+	res.redirect("/homepage");
 });
 
 router.get("/register", defaultController.getRegister);
@@ -31,5 +31,9 @@ router.get("/404", function (req, res) {
 
 router.get("/500", function (req, res) {
 	res.render("vwError/500", { layout: "layouts/login.main.ejs" });
+});
+// Catch-all for undefined routes in this router
+router.use((req, res) => {
+	res.redirect("/404");
 });
 export default router;


### PR DESCRIPTION
Some added feature:
Now: everytime someone try to access from a certain page without route handling, it will automatically redirect to /404 page and catches all fallback for ZAP's Error of: CSP: Failure to Define Directive with No Fallback 